### PR TITLE
fix load image bug

### DIFF
--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -264,6 +264,10 @@ extension MainViewController: UIImagePickerControllerDelegate, UINavigationContr
         
         // save to imageView
         self.imageView.image = image
+        self.prevImage = image
+        if(self.currentStyle != 0) {
+            self.stylizeAndUpdate()
+        }
         self.clearImageButton.isEnabled = true
     }
     


### PR DESCRIPTION
There was a bug where when you loaded a new image:
a) the new image was not stylized based on whatever style was selected
and 
b) the prevImage attribute of the MainViewController was not properly set

This has been fixed with this PR.