### PR TITLE
Remove unused code and serious bug fix

### DIFF
--- a/ImStyle/Base.lproj/Main.storyboard
+++ b/ImStyle/Base.lproj/Main.storyboard
@@ -112,6 +112,17 @@
                                     <action selector="toggleCamera:" destination="BRE-eg-EID" eventType="touchUpInside" id="3EI-id-6z0"/>
                                 </connections>
                             </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ive-yS-abg">
+                                <rect key="frame" x="112" y="331" width="150" height="20"/>
+                                <subviews>
+                                    <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xrd-UY-utZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="150" height="20"/>
+                                    </progressView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="YNx-gb-Nqr"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
@@ -119,6 +130,8 @@
                             <constraint firstItem="nvZ-Fd-sDp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="q1I-ma-Aqc" secondAttribute="leading" constant="20" symbolic="YES" id="3Ng-qR-t0S"/>
                             <constraint firstItem="nvZ-Fd-sDp" firstAttribute="trailing" secondItem="q1I-ma-Aqc" secondAttribute="trailingMargin" id="9s1-9c-Lk7"/>
                             <constraint firstItem="iKA-oc-ihR" firstAttribute="bottom" secondItem="f23-Bz-one" secondAttribute="bottom" id="CLW-L9-hh0"/>
+                            <constraint firstItem="Ive-yS-abg" firstAttribute="leading" secondItem="Ybc-kP-tAC" secondAttribute="leading" constant="112" id="Gi7-A7-siv"/>
+                            <constraint firstItem="Ive-yS-abg" firstAttribute="centerX" secondItem="iKA-oc-ihR" secondAttribute="centerX" id="IcX-ux-i96"/>
                             <constraint firstItem="iKA-oc-ihR" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="550" id="Mtd-Ws-LCw"/>
                             <constraint firstItem="uwq-z8-mjs" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="595" id="S68-R9-yKJ"/>
                             <constraint firstItem="f23-Bz-one" firstAttribute="leading" secondItem="uwq-z8-mjs" secondAttribute="leading" constant="-311" id="UYb-ek-geU"/>
@@ -126,6 +139,7 @@
                             <constraint firstItem="0qU-kT-YCK" firstAttribute="centerX" secondItem="q1I-ma-Aqc" secondAttribute="centerX" id="Xj5-A0-h0U"/>
                             <constraint firstItem="uwq-z8-mjs" firstAttribute="leading" secondItem="q1I-ma-Aqc" secondAttribute="leadingMargin" constant="311" id="cOL-rX-O1n"/>
                             <constraint firstAttribute="bottom" secondItem="f23-Bz-one" secondAttribute="bottom" constant="20" symbolic="YES" id="dsd-YC-YmW"/>
+                            <constraint firstItem="Ive-yS-abg" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="311" id="fSa-f5-Eul"/>
                             <constraint firstAttribute="bottom" secondItem="dPA-3G-PLh" secondAttribute="bottom" constant="20" symbolic="YES" id="gX9-PG-pID"/>
                             <constraint firstItem="0qU-kT-YCK" firstAttribute="top" secondItem="q1I-ma-Aqc" secondAttribute="top" id="hnA-Uh-mvh"/>
                             <constraint firstItem="0qU-kT-YCK" firstAttribute="bottom" secondItem="Ybc-kP-tAC" secondAttribute="bottom" id="mIH-1R-WYG"/>
@@ -146,6 +160,7 @@
                         <outlet property="saveImageButton" destination="nvZ-Fd-sDp" id="k5j-i8-v8B"/>
                         <outlet property="takePhotoButton" destination="iKA-oc-ihR" id="ADS-Ly-8s6"/>
                         <outlet property="toggleCameraButton" destination="uwq-z8-mjs" id="FDf-H2-zwc"/>
+                        <outlet property="videoStyleProgressBar" destination="xrd-UY-utZ" id="4Sc-C4-ygP"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jfQ-mL-VAX" sceneMemberID="firstResponder"/>

--- a/ImStyle/Base.lproj/Main.storyboard
+++ b/ImStyle/Base.lproj/Main.storyboard
@@ -77,23 +77,6 @@
                                     <action selector="save_image:" destination="BRE-eg-EID" eventType="touchUpInside" id="JBM-cP-FU7"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uwq-z8-mjs" userLabel="Toggle Camera Button">
-                                <rect key="frame" x="16" y="28" width="32" height="32"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="32" id="2l4-Ja-hFF"/>
-                                    <constraint firstAttribute="height" constant="32" id="UZP-VJ-V1T"/>
-                                </constraints>
-                                <state key="normal" image="camflip"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="5"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="toggleCamera:" destination="BRE-eg-EID" eventType="touchUpInside" id="3EI-id-6z0"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f23-Bz-one">
                                 <rect key="frame" x="16" y="616" width="31" height="31"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -112,6 +95,23 @@
                                     <action selector="takePhotoAction:" destination="BRE-eg-EID" eventType="touchUpInside" id="EeW-sB-HhR"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uwq-z8-mjs" userLabel="Toggle Camera Button">
+                                <rect key="frame" x="327" y="615" width="32" height="32"/>
+                                <color key="backgroundColor" white="0.66666666669999997" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="32" id="2l4-Ja-hFF"/>
+                                    <constraint firstAttribute="height" constant="32" id="UZP-VJ-V1T"/>
+                                </constraints>
+                                <state key="normal" image="camflip"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="toggleCamera:" destination="BRE-eg-EID" eventType="touchUpInside" id="3EI-id-6z0"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
@@ -120,11 +120,11 @@
                             <constraint firstItem="nvZ-Fd-sDp" firstAttribute="trailing" secondItem="q1I-ma-Aqc" secondAttribute="trailingMargin" id="9s1-9c-Lk7"/>
                             <constraint firstItem="iKA-oc-ihR" firstAttribute="bottom" secondItem="f23-Bz-one" secondAttribute="bottom" id="CLW-L9-hh0"/>
                             <constraint firstItem="iKA-oc-ihR" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="550" id="Mtd-Ws-LCw"/>
-                            <constraint firstItem="uwq-z8-mjs" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="8" id="S68-R9-yKJ"/>
-                            <constraint firstItem="f23-Bz-one" firstAttribute="leading" secondItem="uwq-z8-mjs" secondAttribute="leading" id="UYb-ek-geU"/>
+                            <constraint firstItem="uwq-z8-mjs" firstAttribute="top" secondItem="Ybc-kP-tAC" secondAttribute="top" constant="595" id="S68-R9-yKJ"/>
+                            <constraint firstItem="f23-Bz-one" firstAttribute="leading" secondItem="uwq-z8-mjs" secondAttribute="leading" constant="-311" id="UYb-ek-geU"/>
                             <constraint firstItem="iKA-oc-ihR" firstAttribute="centerX" secondItem="0qU-kT-YCK" secondAttribute="centerX" id="Vjp-Rs-jKU"/>
                             <constraint firstItem="0qU-kT-YCK" firstAttribute="centerX" secondItem="q1I-ma-Aqc" secondAttribute="centerX" id="Xj5-A0-h0U"/>
-                            <constraint firstItem="uwq-z8-mjs" firstAttribute="leading" secondItem="q1I-ma-Aqc" secondAttribute="leadingMargin" id="cOL-rX-O1n"/>
+                            <constraint firstItem="uwq-z8-mjs" firstAttribute="leading" secondItem="q1I-ma-Aqc" secondAttribute="leadingMargin" constant="311" id="cOL-rX-O1n"/>
                             <constraint firstAttribute="bottom" secondItem="f23-Bz-one" secondAttribute="bottom" constant="20" symbolic="YES" id="dsd-YC-YmW"/>
                             <constraint firstAttribute="bottom" secondItem="dPA-3G-PLh" secondAttribute="bottom" constant="20" symbolic="YES" id="gX9-PG-pID"/>
                             <constraint firstItem="0qU-kT-YCK" firstAttribute="top" secondItem="q1I-ma-Aqc" secondAttribute="top" id="hnA-Uh-mvh"/>
@@ -145,6 +145,7 @@
                         <outlet property="loadImageButton" destination="f23-Bz-one" id="S4r-au-O96"/>
                         <outlet property="saveImageButton" destination="nvZ-Fd-sDp" id="k5j-i8-v8B"/>
                         <outlet property="takePhotoButton" destination="iKA-oc-ihR" id="ADS-Ly-8s6"/>
+                        <outlet property="toggleCameraButton" destination="uwq-z8-mjs" id="FDf-H2-zwc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jfQ-mL-VAX" sceneMemberID="firstResponder"/>

--- a/ImStyle/Base.lproj/Main.storyboard
+++ b/ImStyle/Base.lproj/Main.storyboard
@@ -4,7 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -57,7 +57,8 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="takePhotoAction:" destination="BRE-eg-EID" eventType="touchUpInside" id="yOb-xh-VvH"/>
+                                    <action selector="takePhotoTouchDown:" destination="BRE-eg-EID" eventType="touchDown" id="Jzi-2T-bnG"/>
+                                    <action selector="takePhotoTouchUpInside:" destination="BRE-eg-EID" eventType="touchUpInside" id="ysc-tG-Wkc"/>
                                 </connections>
                             </button>
                             <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nvZ-Fd-sDp">

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -229,6 +229,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.takePhotoButton.isEnabled = false
         self.takePhotoButton.isHidden = true
         self.saveImageButton.isEnabled = true
+        self.saveImageButton.isHidden = false
         self.clearImageButton.isEnabled = true
         self.clearImageButton.isHidden = false
         self.loadImageButton.isEnabled = false
@@ -254,6 +255,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.loadImageButton.isHidden = false
         self.toggleCameraButton.isHidden = false
         self.toggleCameraButton.isEnabled = true
+        self.saveImageButton.isEnabled = false
+        self.saveImageButton.isHidden = true
     }
     
     @IBAction func toggleCamera(_ sender: Any) {

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -159,19 +159,6 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             frontCameraSession.startRunning()
         }
     }
-    
-    @IBAction func toggle_transfer(_ sender: Any) {
-        if (!self.perform_transfer) {
-            self.imageView.image = self.prevImage
-        } else if (!perform_transfer && self.takePhotoButton.isEnabled == false) {
-            // save unstyled image
-            self.prevImage = self.imageView.image!
-            self.stylizeAndUpdate()
-        } else {
-            perform_transfer = !perform_transfer
-            self.saveImageButton.isEnabled = perform_transfer
-        }
-    }
 
     @IBAction func save_image(_ sender: Any) {
         UIGraphicsBeginImageContext(CGSize(width: self.imageView.frame.size.width, height: self.imageView.frame.size.height))
@@ -227,6 +214,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             self.displayingVideo = true
             self.videoTimer!.invalidate()
             self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: #selector(renderVideoFrame), userInfo: nil, repeats: true)
+        } else {
+            self.videoTimer!.invalidate()
         }
         self.toggleCameraButton.isEnabled = false
         self.toggleCameraButton.isHidden = true
@@ -296,7 +285,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             self.videoStyleProgressBar.isHidden = false
             self.isStylizingVideo = true
             DispatchQueue.global().async {
-                self.stylizedVideoFrames = []
+                    self.stylizedVideoFrames = []
                 for (index, frame) in self.videoFrames.enumerated() {
                     DispatchQueue.main.async {
                         self.videoStyleProgressBar.progress = Float(index) / Float(self.videoFrames.count)

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -191,6 +191,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.recordingVideo = true
         self.videoPlaybackFrame = 0
         self.videoFrames = []
+        self.stylizedVideoFrames = []
     }
     
     @objc func saveFrame(){

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -178,25 +178,26 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.saveToPhotoLibrary(uiImage: image!)
     }
     
-    func startVideo(){
+    @objc func startVideo() {
         if(self.currentStyle != 0) {
             print("TODO: alert user that you can't record live video in style")
             return
         }
-        self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: Selector(("saveFrame")), userInfo: nil, repeats: true)
+        self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: #selector(saveFrame), userInfo: nil, repeats: true)
         self.loadImageButton.isHidden = true
         self.loadImageButton.isEnabled = false
         self.saveImageButton.isHidden = true
         self.saveImageButton.isEnabled = false
         self.recordingVideo = true
+        self.videoPlaybackFrame = 0
         self.videoFrames = []
     }
     
-    func saveFrame(){
+    @objc func saveFrame(){
         self.videoFrames.append(self.imageView.image!)
     }
     
-    func renderVideoFrame() {
+    @objc func renderVideoFrame() {
         if(self.currentStyle == 0) {
             self.imageView.image = self.videoFrames[self.videoPlaybackFrame]
         } else {
@@ -209,7 +210,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     }
     
     @IBAction func takePhotoTouchDown(_ sender: Any) {
-        self.videoTimer = Timer.scheduledTimer(timeInterval: 0.2, target: self, selector: Selector(("startVideo")), userInfo: nil, repeats: false)
+        self.videoTimer = Timer.scheduledTimer(timeInterval: 0.2, target: self, selector: #selector(startVideo), userInfo: nil, repeats: false)
     }
     
     @IBAction func takePhotoTouchUpInside(_ sender: Any) {
@@ -222,7 +223,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             self.recordingVideo = false
             self.displayingVideo = true
             self.videoTimer!.invalidate()
-            self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: Selector(("renderVideoFrame")), userInfo: nil, repeats: true)
+            self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: #selector(renderVideoFrame), userInfo: nil, repeats: true)
         }
         self.toggleCameraButton.isEnabled = false
         self.toggleCameraButton.isHidden = true
@@ -286,7 +287,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     
     func updateStyle(oldStyle: Int) {
         setModel(targetModel: modelList[self.currentStyle])
-        if(self.displayingVideo) {
+        if(self.displayingVideo && self.currentStyle != 0) {
             for frame in self.videoFrames {
                 self.stylizedVideoFrames.append(applyStyleTransfer(uiImage: frame, model: model))
             }

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -11,6 +11,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     @IBOutlet weak var saveImageButton: UIButton!
     @IBOutlet weak var clearImageButton: UIButton!
     @IBOutlet weak var takePhotoButton: UIButton!
+    @IBOutlet weak var toggleCameraButton: UIButton!
     
     let frontCamera = AVCaptureDevice.default(.builtInWideAngleCamera, for: AVMediaType.video, position: .front)!
     let rearCamera = AVCaptureDevice.default(for: .video)!
@@ -36,10 +37,6 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let tap = UITapGestureRecognizer(target: self, action: #selector(MainViewController.imageTapAction))
-        self.imageView.addGestureRecognizer(tap)
-        self.imageView.isUserInteractionEnabled = true
         
         self.clearImageButton.isEnabled = false
         
@@ -97,7 +94,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         
         self.clearImageButton.isHidden = true
         self.clearImageButton.isEnabled = false
-        
+        self.saveImageButton.isEnabled = false
+        self.saveImageButton.isHidden = true
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -226,6 +224,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             self.videoTimer!.invalidate()
             self.videoTimer = Timer.scheduledTimer(timeInterval: 0.05, target: self, selector: Selector(("renderVideoFrame")), userInfo: nil, repeats: true)
         }
+        self.toggleCameraButton.isEnabled = false
+        self.toggleCameraButton.isHidden = true
         self.takePhotoButton.isEnabled = false
         self.takePhotoButton.isHidden = true
         self.saveImageButton.isEnabled = true
@@ -252,6 +252,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.clearImageButton.isHidden = true
         self.loadImageButton.isEnabled = true
         self.loadImageButton.isHidden = false
+        self.toggleCameraButton.isHidden = false
+        self.toggleCameraButton.isEnabled = true
     }
     
     @IBAction func toggleCamera(_ sender: Any) {
@@ -296,10 +298,6 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         if(self.perform_transfer) {
             self.stylizeAndUpdate()
         }
-    }
-    
-    @objc func imageTapAction() {
-        // Nothing to do here
     }
     
     @IBAction func loadPhotoButtonPressed(_ sender: Any) {


### PR DESCRIPTION
There was a bug in video transfer where when a photo was taken instead of a video, the Timer to record video frames was not invalidated. The symptoms of this were that if a photo was taken and then later a video was taken, the video would actually be all of the frames captures since the original photo was taken. However, this is now fixed.
Close #34.
Do not merge until #40 is merged.