### PR TITLE
remove crash from load image button

### DIFF
--- a/ImStyle/Base.lproj/Main.storyboard
+++ b/ImStyle/Base.lproj/Main.storyboard
@@ -92,7 +92,6 @@
                                 </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="loadPhotoButtonPressed:" destination="BRE-eg-EID" eventType="touchUpInside" id="lOJ-0h-6Yr"/>
-                                    <action selector="takePhotoAction:" destination="BRE-eg-EID" eventType="touchUpInside" id="EeW-sB-HhR"/>
                                 </connections>
                             </button>
                             <button opaque="NO" alpha="0.75" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uwq-z8-mjs" userLabel="Toggle Camera Button">


### PR DESCRIPTION
This was caused by an extra unused reference in the storyboard. Close #49 