### PR TITLE
Add swipe functionality during styling

### DIFF
--- a/ImStyle.xcodeproj/project.pbxproj
+++ b/ImStyle.xcodeproj/project.pbxproj
@@ -451,11 +451,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 554X9B982N;
+				DEVELOPMENT_TEAM = W93W78DLP2;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = ImStyle/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ImageStyle.ImStyle;
+				PRODUCT_BUNDLE_IDENTIFIER = ImageStyle.ImStyl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.0;
@@ -468,11 +468,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 554X9B982N;
+				DEVELOPMENT_TEAM = W93W78DLP2;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = ImStyle/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ImageStyle.ImStyle;
+				PRODUCT_BUNDLE_IDENTIFIER = ImageStyle.ImStyl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.0;

--- a/ImStyle/MainViewController.swift
+++ b/ImStyle/MainViewController.swift
@@ -318,6 +318,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
                     }
                 }
             }
+        } else {
+            self.videoStyleProgressBar.isHidden = true
         }
         if(oldStyle == 0) {
             self.prevImage = self.imageView.image;


### PR DESCRIPTION
This is a pretty complex change, and I think that there is a super super ultra rare case where the progress bar won't be shown. Basically if the thread switches from main to background between the lines: 
 `self.videoStyleProgressBar.isHidden = false`
and 
`self.isStylizingVideo = true`
Then while the styling is happening, the progress bar won't be shown save and clear image buttons will be enabled. This can be fixed by putting those three lines inside the for loop in the async. That's a bit of a hack, but I am willing to do it.

This is already a double-locking mechanism. The main thread makes a call to asynchronous thread. This call includes another asynchronous call back to the main thread. Please be very cautious when modifying this code in the future.

**EDIT: the third commit in this PR fixes the above issue by introducing a third lock**
Close #41 